### PR TITLE
Add verbose flag. Make fancy features optional.

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -65,7 +65,7 @@ and configuration. The stack must be stopped to run this command.`,
 
 		fmt.Printf("deleting FireFly stack '%s'... ", stackName)
 		workingDir := path.Join(stacks.StacksDir, stackName)
-		if err := docker.RunDockerComposeCommand(workingDir, "rm", "-f"); err != nil {
+		if err := docker.RunDockerComposeCommand(workingDir, verbose, "rm", "-f"); err != nil {
 			return fmt.Errorf("command finished with error: %v", err)
 		}
 		os.RemoveAll(path.Join(stacks.StacksDir, stackName))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,9 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -23,6 +26,9 @@ import (
 )
 
 var cfgFile string
+var ansi string
+var fancyFeatures bool
+var verbose bool
 
 func GetFireflyAsciiArt() string {
 	s := ""
@@ -49,6 +55,15 @@ commands to manage the lifecycle of stacks.
 
 To get started run: ff init
 	`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if ansi == "always" {
+			fancyFeatures = true
+		} else if ansi == "auto" && (isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())) {
+			fancyFeatures = true
+		} else {
+			fancyFeatures = false
+		}
+	},
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
@@ -57,6 +72,8 @@ To get started run: ff init
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	rootCmd.PersistentFlags().StringVarP(&ansi, "ansi", "", "auto", "control when to print ANSI control characters (\"never\"|\"always\"|\"auto\") (default \"auto\")")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose log output")
 	cobra.CheckErr(rootCmd.Execute())
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -43,7 +43,7 @@ This command will start a stack and run it in the background.
 			return err
 		}
 
-		if err = stack.StartStack(); err != nil {
+		if err = stack.StartStack(fancyFeatures, verbose); err != nil {
 			return err
 		} else {
 			fmt.Print("\n\n")

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -41,7 +41,7 @@ var stopCmd = &cobra.Command{
 		}
 		workingDir := path.Join(stacks.StacksDir, stackName)
 		fmt.Printf("stopping stack '%s'...", stackName)
-		if err := docker.RunDockerComposeCommand(workingDir, "stop"); err != nil {
+		if err := docker.RunDockerComposeCommand(workingDir, verbose, "stop"); err != nil {
 			return fmt.Errorf("command finished with error: %v", err)
 		} else {
 			fmt.Print("done\n")

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/btcsuite/btcd v0.21.0-beta
 	github.com/castillobgr/sententia v0.0.0-20160918013314-9b04b4a53625
 	github.com/libp2p/go-libp2p-core v0.8.5
+	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nguyer/promptui v0.8.1-0.20210517133143-d9a192af4368
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1yA=
+github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
@@ -342,6 +344,7 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988 h1:EjgCl+fVlIaPJSori0ikSz3uV0DOHKWOJFpv1sAAhBM=
 golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
To enable verbose logs add `-v` anywhere to the command line

To disable fancy features such as colors and spinners, add the `--ansi never` flag to the command line