### PR TITLE
Fix startup crash on FireFly core

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -33,7 +33,7 @@ var initCmd = &cobra.Command{
 	Long:  `Create a new FireFly local dev stack`,
 	Args:  cobra.MaximumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Initializing new FireFly stack...")
+		fmt.Println("initializing new FireFly stack...")
 
 		validateName := func(stackName string) error {
 			if exists, err := stacks.CheckExists(stackName); exists {
@@ -53,7 +53,7 @@ var initCmd = &cobra.Command{
 		} else {
 			defaultStackName, _ := sententia.Make("{{ adjective }}-{{ nouns }}")
 			prompt := promptui.Prompt{
-				Label:    "Stack name",
+				Label:    "stack name",
 				Default:  defaultStackName,
 				Validate: validateName,
 			}
@@ -77,7 +77,7 @@ var initCmd = &cobra.Command{
 			}
 		} else {
 			prompt := promptui.Prompt{
-				Label:    "Number of members",
+				Label:    "number of members",
 				Default:  "2",
 				Validate: validateCount,
 			}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -46,7 +46,7 @@ output with the -f flag.`,
 			return err
 		}
 
-		fmt.Println("Getting logs...")
+		fmt.Println("getting logs... ")
 
 		stackDir := path.Join(stacks.StacksDir, stackName)
 		commandLine := []string{"logs"}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -40,7 +40,7 @@ var stopCmd = &cobra.Command{
 			return fmt.Errorf("stack '%s' does not exist", stackName)
 		}
 		workingDir := path.Join(stacks.StacksDir, stackName)
-		fmt.Printf("stopping stack '%s'...", stackName)
+		fmt.Printf("stopping stack '%s'... ", stackName)
 		if err := docker.RunDockerComposeCommand(workingDir, verbose, "stop"); err != nil {
 			return fmt.Errorf("command finished with error: %v", err)
 		} else {

--- a/internal/stacks/fireflyConfig.go
+++ b/internal/stacks/fireflyConfig.go
@@ -1,5 +1,11 @@
 package stacks
 
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
 type LogConfig struct {
 	Level string `yaml:"level,omitempty"`
 }
@@ -105,9 +111,10 @@ func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
 				Type: "ethereum",
 				Ethereum: &EthereumConfig{
 					Ethconnect: &EthconnectConfig{
-						URL:      "http://ethconnect_" + member.ID + ":8080",
-						Instance: "/contracts/firefly",
-						Topic:    member.ID,
+						URL:                 "http://ethconnect_" + member.ID + ":8080",
+						Instance:            "/contracts/firefly",
+						Topic:               member.ID,
+						SkipEventStreamInit: true,
 					},
 				},
 			},
@@ -134,4 +141,23 @@ func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
 		}
 	}
 	return configs
+}
+
+func ReadFireflyConfig(filePath string) (*FireflyConfig, error) {
+	if bytes, err := ioutil.ReadFile(filePath); err != nil {
+		return nil, err
+	} else {
+		var config *FireflyConfig
+		err := yaml.Unmarshal(bytes, &config)
+		return config, err
+	}
+}
+
+func WriteFireflyConfig(config *FireflyConfig, filePath string) error {
+	if bytes, err := yaml.Marshal(config); err != nil {
+		return err
+	} else {
+		ioutil.WriteFile(filePath, bytes, 0755)
+		return nil
+	}
 }


### PR DESCRIPTION
This PR changes the default config for FireFly core to skip subscription initialization the first time it comes up. It then loads the contracts into ethconnect. It will then shut down each FireFly core node, change its config to not skip subscription initialization, and then start each node again.

This means that when the `start` command returns, the entire stack should be ready to use.